### PR TITLE
update cloudflare before create tunnel

### DIFF
--- a/colab_ssh/tunel.py
+++ b/colab_ssh/tunel.py
@@ -27,6 +27,11 @@ def config_argo_tunnel(msg: str):
         print("Seems like we already had cloudflared binary")
         pass
     cfd_proc = subprocess.Popen(
+        ["./cloudflared", "update"],
+        stdout=subprocess.PIPE,
+        universal_newlines=True
+    )
+    cfd_proc = subprocess.Popen(
         ["./cloudflared", "tunnel", "--url", "ssh://localhost:22",
          "--logfile", "cloudflared.log", "--metrics", "localhost:49589"],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Fix #3
I figure it out that the reason Cloudflare can't run is the version of it still is `2021.5.9`. So I run `./cloudflare update` before creating a tunnel to fix the problem. I have tested on colab notebook.